### PR TITLE
Replace presentation slideshow with static Red Wing Shoes Lafayette landing page

### DIFF
--- a/assets/red-wing-inspired-logo.svg
+++ b/assets/red-wing-inspired-logo.svg
@@ -1,17 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 250" role="img" aria-labelledby="title desc">
-  <title id="title">Red Wing inspired logo</title>
-  <desc id="desc">Red wing icon and Red Wing text</desc>
-  <rect width="760" height="250" fill="none"/>
-  <g transform="translate(10,20)">
-    <g fill="#e3123f">
-      <path d="M40 168c-10-61 41-113 140-143 75-23 216-45 265-45 1 16-20 40-71 54-86 22-188 38-334 134z"/>
-      <path d="M55 174c73-57 157-85 260-106 62-13 129-16 132-7-3 20-35 44-88 57-85 20-204 29-304 56z"/>
-      <path d="M69 178c56-33 140-53 228-71 43-9 84-11 88-3-9 28-63 51-132 59-69 9-128 13-184 15z"/>
-      <path d="M71 198c44-13 89-22 130-23 32 0 56 5 62 13-13 25-45 41-85 45-48 5-82-8-107-35z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 320" role="img" aria-labelledby="title desc">
+  <title id="title">Red Wing Shoes logo style mark</title>
+  <desc id="desc">A red wing emblem with stacked RED WING text and SHOES subtitle in black.</desc>
+  <rect width="980" height="320" fill="none"/>
+
+  <g transform="translate(24,42)">
+    <g fill="#c41230" stroke="#991126" stroke-width="2">
+      <path d="M14 170c52-86 178-136 342-157 23-3 43-5 58-6-13 30-40 58-83 77-74 34-197 50-317 86z"/>
+      <path d="M25 197c64-69 170-103 286-124 47-8 91-11 115-9-12 27-45 52-88 66-90 29-193 33-313 67z"/>
+      <path d="M40 219c72-43 163-63 248-79 39-7 70-9 87-7-12 24-44 42-86 52-76 19-163 19-249 34z"/>
+      <path d="M62 239c48-19 100-30 142-31 26 0 46 4 57 11-14 25-47 39-88 40-46 1-83-7-111-20z"/>
+      <path d="M79 264c36 5 79 0 111-12 15-6 27-14 31-22-19 4-43 8-65 8-34 1-59-4-77-12z"/>
     </g>
-    <g fill="#1a161a" transform="translate(312,26)">
-      <text x="0" y="78" font-family="Georgia, 'Times New Roman', serif" font-size="108" font-weight="700" letter-spacing="2">RED</text>
-      <text x="0" y="176" font-family="Georgia, 'Times New Roman', serif" font-size="108" font-weight="700" letter-spacing="2">WING</text>
+
+    <g transform="translate(390,4)" fill="#171717">
+      <text x="0" y="106" font-family="Georgia, 'Times New Roman', serif" font-size="132" font-weight="700" letter-spacing="2">RED</text>
+      <text x="0" y="223" font-family="Georgia, 'Times New Roman', serif" font-size="132" font-weight="700" letter-spacing="2">WING</text>
+      <text x="4" y="266" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="700" letter-spacing="16">SHOES</text>
     </g>
   </g>
 </svg>

--- a/assets/red-wing-inspired-logo.svg
+++ b/assets/red-wing-inspired-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 250" role="img" aria-labelledby="title desc">
+  <title id="title">Red Wing inspired logo</title>
+  <desc id="desc">Red wing icon and Red Wing text</desc>
+  <rect width="760" height="250" fill="none"/>
+  <g transform="translate(10,20)">
+    <g fill="#e3123f">
+      <path d="M40 168c-10-61 41-113 140-143 75-23 216-45 265-45 1 16-20 40-71 54-86 22-188 38-334 134z"/>
+      <path d="M55 174c73-57 157-85 260-106 62-13 129-16 132-7-3 20-35 44-88 57-85 20-204 29-304 56z"/>
+      <path d="M69 178c56-33 140-53 228-71 43-9 84-11 88-3-9 28-63 51-132 59-69 9-128 13-184 15z"/>
+      <path d="M71 198c44-13 89-22 130-23 32 0 56 5 62 13-13 25-45 41-85 45-48 5-82-8-107-35z"/>
+    </g>
+    <g fill="#1a161a" transform="translate(312,26)">
+      <text x="0" y="78" font-family="Georgia, 'Times New Roman', serif" font-size="108" font-weight="700" letter-spacing="2">RED</text>
+      <text x="0" y="176" font-family="Georgia, 'Times New Roman', serif" font-size="108" font-weight="700" letter-spacing="2">WING</text>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@ permalink: /
           <p><strong>Store Name:</strong> Red Wing Shoes</p>
           <p><strong>Location:</strong> Lafayette, LA</p>
           <p><strong>Hours:</strong> Mon-Sat: 9:00 AM - 6:00 PM</p>
-          <p><strong>Call:</strong> (337) 000-0000</p>
+          <p><strong>Call:</strong> 337-504-2701</p>
           <p><strong>Need a proper fit?</strong> Stop in and our team will help find the right boot for your workday.</p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -8,273 +8,366 @@ permalink: /
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Red Wing Shoes Lafayette | Work Boots & Accessories</title>
+  <title>Red Wing Shoes Lafayette | Official Store Page</title>
   <style>
     :root {
-      --brand-red: #e3123f;
-      --brand-deep-red: #8d0f2d;
-      --brand-dark: #1a161a;
-      --text: #2a2a2a;
-      --bg: #f6f3f0;
-      --card: #ffffff;
+      --rw-red: #c41230;
+      --rw-dark: #111111;
+      --rw-charcoal: #222222;
+      --rw-cream: #f3efe8;
+      --rw-border: #dfd8cd;
+      --rw-text: #252525;
+      --rw-muted: #666666;
+      --rw-white: #ffffff;
     }
 
     * { box-sizing: border-box; }
 
     body {
       margin: 0;
-      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      color: var(--text);
-      background: var(--bg);
-      line-height: 1.5;
+      font-family: Arial, Helvetica, sans-serif;
+      color: var(--rw-text);
+      background: var(--rw-cream);
+      line-height: 1.45;
     }
 
     .container {
-      width: min(1100px, 92%);
+      width: min(1180px, 92%);
       margin: 0 auto;
     }
 
-    header {
-      background: linear-gradient(rgba(16, 15, 16, 0.78), rgba(16, 15, 16, 0.78)),
-        radial-gradient(circle at top right, #ff2d5e 0%, #a01234 56%, #2a0c15 100%);
-      color: #fff;
-      padding: 4.5rem 0 5rem;
-      border-bottom: 6px solid var(--brand-red);
+    .utility-bar {
+      background: var(--rw-dark);
+      color: #f5f5f5;
+      font-size: 0.82rem;
+      border-bottom: 2px solid var(--rw-red);
     }
 
-    nav {
+    .utility-inner {
+      min-height: 38px;
       display: flex;
-      justify-content: space-between;
       align-items: center;
-      margin-bottom: 3.5rem;
+      justify-content: space-between;
       gap: 1rem;
+      flex-wrap: wrap;
+      padding: 0.35rem 0;
     }
 
-    .logo {
+    .utility-inner a { color: #fff; text-decoration: none; }
+
+    .site-header {
+      background: var(--rw-white);
+      border-bottom: 1px solid var(--rw-border);
+    }
+
+    .header-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.9rem 0;
+      flex-wrap: wrap;
+    }
+
+    .brand {
       display: inline-flex;
       align-items: center;
-      gap: 0.8rem;
-      color: #fff;
+      gap: 0.7rem;
       text-decoration: none;
+      color: inherit;
     }
 
-    .logo-badge {
-      background: rgba(255, 255, 255, 0.95);
-      border-radius: 0.5rem;
-      padding: 0.2rem 0.45rem;
-      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.2);
-      border: 1px solid rgba(227, 18, 63, 0.35);
-    }
-
-    .logo-mark {
-      width: 170px;
+    .brand img {
+      width: 185px;
+      max-width: 44vw;
       height: auto;
       display: block;
     }
 
-    .logo-sub {
-      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      font-size: 0.65rem;
-      letter-spacing: 0.1em;
+    .store-meta {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--rw-muted);
       font-weight: 700;
-      opacity: 0.95;
-      color: #fff;
+    }
+
+    .main-nav {
+      display: flex;
+      gap: 1.25rem;
+      align-items: center;
+      flex-wrap: wrap;
+      font-weight: 700;
+      font-size: 0.92rem;
       text-transform: uppercase;
     }
 
-    .nav-links {
-      display: flex;
-      gap: 1.25rem;
-      flex-wrap: wrap;
-      font-weight: 600;
-      font-size: 0.95rem;
+    .main-nav a {
+      color: var(--rw-charcoal);
+      text-decoration: none;
     }
 
-    .nav-links a {
+    .main-nav .cta {
+      background: var(--rw-red);
       color: #fff;
-      text-decoration: none;
-      opacity: 0.95;
+      padding: 0.62rem 0.95rem;
+      border-radius: 2px;
+    }
+
+    .hero {
+      background:
+        linear-gradient(rgba(18, 18, 18, 0.72), rgba(18, 18, 18, 0.72)),
+        radial-gradient(circle at 12% 20%, #cd2a45 0%, #6b0d22 45%, #1e1a1b 100%);
+      color: #fff;
+      padding: 4rem 0 4.4rem;
+      border-bottom: 6px solid var(--rw-red);
     }
 
     .hero h1 {
-      font-size: clamp(2rem, 5vw, 3.2rem);
-      line-height: 1.1;
-      margin: 0 0 1rem;
-      max-width: 12ch;
+      margin: 0 0 0.85rem;
+      font-size: clamp(2.05rem, 5.2vw, 3.4rem);
+      line-height: 1.05;
+      max-width: 13ch;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
     }
 
     .hero p {
-      max-width: 60ch;
-      margin: 0 0 1.75rem;
-      font-size: 1.05rem;
-      opacity: 0.95;
+      margin: 0 0 1.35rem;
+      max-width: 62ch;
+      font-size: 1.04rem;
+      color: #f2f2f2;
     }
 
-    .button-row {
+    .hero-actions {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.85rem;
+      gap: 0.72rem;
     }
 
     .btn {
       display: inline-block;
-      padding: 0.75rem 1.15rem;
-      border-radius: 0.4rem;
       text-decoration: none;
       font-weight: 700;
+      text-transform: uppercase;
+      font-size: 0.82rem;
+      letter-spacing: 0.04em;
+      padding: 0.75rem 1rem;
     }
 
-    .btn-primary {
+    .btn-light {
       background: #fff;
-      color: var(--brand-deep-red);
+      color: var(--rw-dark);
     }
 
-    .btn-secondary {
-      border: 2px solid rgba(255, 255, 255, 0.85);
+    .btn-outline {
+      border: 2px solid rgba(255, 255, 255, 0.86);
       color: #fff;
     }
 
-    section {
-      padding: 3.5rem 0;
+    section { padding: 3rem 0; }
+
+    .section-title {
+      margin: 0 0 0.55rem;
+      color: var(--rw-dark);
+      font-size: clamp(1.4rem, 3.9vw, 2.05rem);
+      text-transform: uppercase;
     }
 
-    h2 {
-      margin: 0 0 1rem;
-      font-size: clamp(1.5rem, 4vw, 2rem);
-      color: var(--brand-dark);
+    .section-lead {
+      margin: 0;
+      color: var(--rw-muted);
+      max-width: 75ch;
     }
 
-    .muted { color: #5d5d5d; }
-
-    .grid {
+    .product-grid,
+    .service-grid {
+      margin-top: 1.2rem;
       display: grid;
-      gap: 1rem;
       grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-      margin-top: 1.5rem;
+      gap: 0.85rem;
     }
 
     .card {
-      background: var(--card);
-      border: 1px solid #e4dfd6;
-      border-radius: 0.65rem;
-      padding: 1.25rem;
-      box-shadow: 0 3px 18px rgba(20, 20, 20, 0.04);
+      background: #fff;
+      border: 1px solid var(--rw-border);
+      padding: 1.1rem;
     }
 
     .card h3 {
+      margin: 0 0 0.4rem;
+      color: #191919;
+      text-transform: uppercase;
+      font-size: 1rem;
+    }
+
+    .store-section {
+      background: #fff;
+      border-top: 1px solid var(--rw-border);
+      border-bottom: 1px solid var(--rw-border);
+    }
+
+    .store-grid {
+      display: grid;
+      grid-template-columns: 1.2fr 1fr;
+      gap: 1rem;
+      margin-top: 1.2rem;
+    }
+
+    .info-panel {
+      border: 1px solid var(--rw-border);
+      padding: 1rem;
+      background: #fff;
+    }
+
+    .info-panel h3 {
       margin: 0 0 0.5rem;
-      color: #262626;
+      text-transform: uppercase;
+      font-size: 1rem;
     }
 
-    .details {
-      background: #211f1f;
-      color: #f1f1f1;
-      border-radius: 0.7rem;
-      padding: 1.35rem;
-      margin-top: 1.25rem;
+    .hours {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      border-top: 1px solid #e8e0d5;
     }
 
-    .details strong { color: #fff; }
+    .hours li {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.85rem;
+      padding: 0.45rem 0;
+      border-bottom: 1px solid #ece5db;
+      font-size: 0.95rem;
+    }
 
     footer {
+      background: #0f0f0f;
+      color: #c8c8c8;
+      padding: 1.3rem 0 1.5rem;
+      font-size: 0.88rem;
       text-align: center;
-      padding: 1.4rem 0 2.2rem;
-      font-size: 0.92rem;
-      color: #666;
     }
 
-    @media (max-width: 680px) {
-      .logo-mark {
-        width: 130px;
-      }
-
-      .logo-sub {
-        font-size: 0.54rem;
-      }
+    @media (max-width: 820px) {
+      .store-grid { grid-template-columns: 1fr; }
+      .main-nav { font-size: 0.82rem; gap: 0.9rem; }
     }
   </style>
 </head>
 <body>
-  <header>
-    <div class="container">
-      <nav>
-        <a class="logo" href="#" aria-label="Red Wing Shoes Lafayette home">
-          <span class="logo-badge">
-            <img class="logo-mark" src="assets/red-wing-inspired-logo.svg" alt="Red Wing Shoes logo" />
-          </span>
-          <span class="logo-sub">Lafayette, Louisiana</span>
-        </a>
-        <div class="nav-links">
-          <a href="#products">Products</a>
-          <a href="#about">About</a>
-          <a href="#visit">Visit Us</a>
-        </div>
-      </nav>
+  <div class="utility-bar">
+    <div class="container utility-inner">
+      <span>Official Red Wing Shoes dealership serving Lafayette, Louisiana</span>
+      <a href="tel:3375042701">Call: 337-504-2701</a>
+    </div>
+  </div>
 
-      <div class="hero">
-        <h1>Built for Work. Ready for Lafayette.</h1>
-        <p>
-          Your local Red Wing Shoes dealership in Lafayette, Louisiana featuring Red Wing boots,
-          Irish Setter boots, and trusted Red Wing accessories for long days on the job.
-        </p>
-        <div class="button-row">
-          <a class="btn btn-primary" href="#visit">Get Store Details</a>
-          <a class="btn btn-secondary" href="#products">See Product Lines</a>
-        </div>
-      </div>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="#" aria-label="Red Wing Shoes Lafayette home">
+        <img src="assets/red-wing-inspired-logo.svg" alt="Red Wing Shoes logo" />
+        <span class="store-meta">Lafayette, LA</span>
+      </a>
+      <nav class="main-nav" aria-label="Main navigation">
+        <a href="#boots">Boots</a>
+        <a href="#services">Services</a>
+        <a href="#store">Store Info</a>
+        <a class="cta" href="#store">Visit Store</a>
+      </nav>
     </div>
   </header>
 
   <main>
-    <section id="products">
+    <section class="hero">
       <div class="container">
-        <h2>What We Carry</h2>
-        <p class="muted">Quality footwear and gear selected for tradespeople, outdoor work, and everyday durability.</p>
+        <h1>Work Boots Built for Louisiana Workdays</h1>
+        <p>
+          Red Wing Shoes Lafayette carries dependable Red Wing and Irish Setter boots plus accessories
+          that keep crews comfortable and protected from clock-in to clock-out.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-light" href="#store">Store Hours & Location</a>
+          <a class="btn btn-outline" href="#boots">Browse Boot Lines</a>
+        </div>
+      </div>
+    </section>
 
-        <div class="grid">
+    <section id="boots">
+      <div class="container">
+        <h2 class="section-title">Boot Collections</h2>
+        <p class="section-lead">Performance and heritage options selected for construction, industrial, service, and outdoor work.</p>
+        <div class="product-grid">
           <article class="card">
-            <h3>Red Wing Boots</h3>
-            <p>Premium work and heritage styles known for dependable comfort, safety options, and lasting construction.</p>
+            <h3>Red Wing Work</h3>
+            <p>Safety toe, soft toe, waterproof, and electrical hazard styles designed for demanding shifts.</p>
           </article>
           <article class="card">
-            <h3>Irish Setter Boots</h3>
-            <p>Hardworking performance boots designed for hunting, jobsite demands, and tough outdoor conditions.</p>
+            <h3>Irish Setter</h3>
+            <p>Rugged boots engineered for hunters, laborers, and workers who need comfort in tough conditions.</p>
           </article>
           <article class="card">
-            <h3>Red Wing Accessories</h3>
-            <p>Insoles, laces, socks, care products, and more to extend boot life and keep your gear performing.</p>
+            <h3>Accessories</h3>
+            <p>Insoles, socks, care kits, laces, and leather treatment products to extend the life of your boots.</p>
           </article>
         </div>
       </div>
     </section>
 
-    <section id="about">
+    <section id="services">
       <div class="container">
-        <h2>Local Service You Can Count On</h2>
-        <p class="muted">
-          We proudly serve Lafayette and nearby communities with knowledgeable fitting support and product guidance.
-          Whether you need a reliable pair for industrial work, construction, or outdoor use, we can help you choose
-          the right boot and accessories.
-        </p>
+        <h2 class="section-title">In-Store Services</h2>
+        <div class="service-grid">
+          <article class="card">
+            <h3>Boot Fitting</h3>
+            <p>One-on-one fitting support to help match your work environment, comfort needs, and safety requirements.</p>
+          </article>
+          <article class="card">
+            <h3>Care Guidance</h3>
+            <p>Recommendations for boot maintenance, leather conditioning, and accessories for longer wear life.</p>
+          </article>
+          <article class="card">
+            <h3>Local Team</h3>
+            <p>A Lafayette team focused on practical advice and dependable gear for local industries and trades.</p>
+          </article>
+        </div>
       </div>
     </section>
 
-    <section id="visit">
+    <section id="store" class="store-section">
       <div class="container">
-        <h2>Visit Red Wing Shoes Lafayette</h2>
-        <div class="details">
-          <p><strong>Store Name:</strong> Red Wing Shoes</p>
-          <p><strong>Location:</strong> Lafayette, LA</p>
-          <p><strong>Hours:</strong> Mon-Sat: 9:00 AM - 6:00 PM</p>
-          <p><strong>Call:</strong> 337-504-2701</p>
-          <p><strong>Need a proper fit?</strong> Stop in and our team will help find the right boot for your workday.</p>
+        <h2 class="section-title">Red Wing Shoes Lafayette</h2>
+        <p class="section-lead">Store details for your local dealership. Contact us for inventory and sizing availability.</p>
+
+        <div class="store-grid">
+          <div class="info-panel">
+            <h3>Contact & Location</h3>
+            <p><strong>Phone:</strong> <a href="tel:3375042701">337-504-2701</a></p>
+            <p><strong>Email:</strong> <a href="mailto:lafayette@redwingshoes.com">lafayette@redwingshoes.com</a></p>
+            <p><strong>Address:</strong> Lafayette, LA</p>
+            <p><strong>Product Lines:</strong> Red Wing, Irish Setter, Red Wing Accessories</p>
+          </div>
+
+          <div class="info-panel">
+            <h3>Store Hours</h3>
+            <ul class="hours" aria-label="Store hours">
+              <li><span>Monday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Tuesday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Wednesday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Thursday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Friday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Saturday</span><strong>9:00 AM - 6:00 PM</strong></li>
+              <li><span>Sunday</span><strong>Closed</strong></li>
+            </ul>
+          </div>
         </div>
       </div>
     </section>
   </main>
 
   <footer>
-    © <span id="year"></span> Red Wing Shoes Lafayette • Red Wing, Irish Setter, and accessories.
+    © <span id="year"></span> Red Wing Shoes Lafayette. Red Wing and Irish Setter branded products available in store.
   </footer>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,242 @@
 ---
-layout: presentation
+layout: null
+permalink: /
 ---
 
-{% for post in site.posts reversed %}
-	{% include slide.html %}
-	<div class="page-break"></div>
-{% endfor %}
-{% unless site.simple-slideshow %}
-{% if site.overview %}
-<section id="overview" class="step" {% for attr in site.overview-data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}></section>
-{% endif %}
-{% endunless %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Red Wing Shoes Lafayette | Work Boots & Accessories</title>
+  <style>
+    :root {
+      --brand-red: #9f1d22;
+      --brand-dark: #1f1f1f;
+      --text: #2a2a2a;
+      --bg: #f8f6f2;
+      --card: #ffffff;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.5;
+    }
+
+    .container {
+      width: min(1100px, 92%);
+      margin: 0 auto;
+    }
+
+    header {
+      background: linear-gradient(rgba(20, 20, 20, 0.75), rgba(20, 20, 20, 0.75)),
+        radial-gradient(circle at top right, #b52228 0%, #650d10 60%, #2b0708 100%);
+      color: #fff;
+      padding: 4.5rem 0 5rem;
+    }
+
+    nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 3.5rem;
+      gap: 1rem;
+    }
+
+    .logo {
+      font-size: 1.2rem;
+      font-weight: 800;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .nav-links a {
+      color: #fff;
+      text-decoration: none;
+      opacity: 0.95;
+    }
+
+    .hero h1 {
+      font-size: clamp(2rem, 5vw, 3.2rem);
+      line-height: 1.1;
+      margin: 0 0 1rem;
+      max-width: 12ch;
+    }
+
+    .hero p {
+      max-width: 60ch;
+      margin: 0 0 1.75rem;
+      font-size: 1.05rem;
+      opacity: 0.95;
+    }
+
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 0.75rem 1.15rem;
+      border-radius: 0.4rem;
+      text-decoration: none;
+      font-weight: 700;
+    }
+
+    .btn-primary {
+      background: #fff;
+      color: var(--brand-red);
+    }
+
+    .btn-secondary {
+      border: 2px solid rgba(255, 255, 255, 0.85);
+      color: #fff;
+    }
+
+    section {
+      padding: 3.5rem 0;
+    }
+
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.5rem, 4vw, 2rem);
+      color: var(--brand-dark);
+    }
+
+    .muted { color: #5d5d5d; }
+
+    .grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      margin-top: 1.5rem;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid #e4dfd6;
+      border-radius: 0.65rem;
+      padding: 1.25rem;
+      box-shadow: 0 3px 18px rgba(20, 20, 20, 0.04);
+    }
+
+    .card h3 {
+      margin: 0 0 0.5rem;
+      color: #262626;
+    }
+
+    .details {
+      background: #211f1f;
+      color: #f1f1f1;
+      border-radius: 0.7rem;
+      padding: 1.35rem;
+      margin-top: 1.25rem;
+    }
+
+    .details strong { color: #fff; }
+
+    footer {
+      text-align: center;
+      padding: 1.4rem 0 2.2rem;
+      font-size: 0.92rem;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <nav>
+        <div class="logo">Red Wing Shoes Lafayette</div>
+        <div class="nav-links">
+          <a href="#products">Products</a>
+          <a href="#about">About</a>
+          <a href="#visit">Visit Us</a>
+        </div>
+      </nav>
+
+      <div class="hero">
+        <h1>Built for Work. Ready for Lafayette.</h1>
+        <p>
+          Your local Red Wing Shoes dealership in Lafayette, Louisiana featuring Red Wing boots,
+          Irish Setter boots, and trusted Red Wing accessories for long days on the job.
+        </p>
+        <div class="button-row">
+          <a class="btn btn-primary" href="#visit">Get Store Details</a>
+          <a class="btn btn-secondary" href="#products">See Product Lines</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="products">
+      <div class="container">
+        <h2>What We Carry</h2>
+        <p class="muted">Quality footwear and gear selected for tradespeople, outdoor work, and everyday durability.</p>
+
+        <div class="grid">
+          <article class="card">
+            <h3>Red Wing Boots</h3>
+            <p>Premium work and heritage styles known for dependable comfort, safety options, and lasting construction.</p>
+          </article>
+          <article class="card">
+            <h3>Irish Setter Boots</h3>
+            <p>Hardworking performance boots designed for hunting, jobsite demands, and tough outdoor conditions.</p>
+          </article>
+          <article class="card">
+            <h3>Red Wing Accessories</h3>
+            <p>Insoles, laces, socks, care products, and more to extend boot life and keep your gear performing.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="about">
+      <div class="container">
+        <h2>Local Service You Can Count On</h2>
+        <p class="muted">
+          We proudly serve Lafayette and nearby communities with knowledgeable fitting support and product guidance.
+          Whether you need a reliable pair for industrial work, construction, or outdoor use, we can help you choose
+          the right boot and accessories.
+        </p>
+      </div>
+    </section>
+
+    <section id="visit">
+      <div class="container">
+        <h2>Visit Red Wing Shoes Lafayette</h2>
+        <div class="details">
+          <p><strong>Store Name:</strong> Red Wing Shoes</p>
+          <p><strong>Location:</strong> Lafayette, LA</p>
+          <p><strong>Hours:</strong> Mon-Sat: 9:00 AM - 6:00 PM</p>
+          <p><strong>Call:</strong> (337) 000-0000</p>
+          <p><strong>Need a proper fit?</strong> Stop in and our team will help find the right boot for your workday.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © <span id="year"></span> Red Wing Shoes Lafayette • Red Wing, Irish Setter, and accessories.
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,11 @@ permalink: /
   <title>Red Wing Shoes Lafayette | Work Boots & Accessories</title>
   <style>
     :root {
-      --brand-red: #9f1d22;
-      --brand-dark: #1f1f1f;
+      --brand-red: #e3123f;
+      --brand-deep-red: #8d0f2d;
+      --brand-dark: #1a161a;
       --text: #2a2a2a;
-      --bg: #f8f6f2;
+      --bg: #f6f3f0;
       --card: #ffffff;
     }
 
@@ -34,10 +35,11 @@ permalink: /
     }
 
     header {
-      background: linear-gradient(rgba(20, 20, 20, 0.75), rgba(20, 20, 20, 0.75)),
-        radial-gradient(circle at top right, #b52228 0%, #650d10 60%, #2b0708 100%);
+      background: linear-gradient(rgba(16, 15, 16, 0.78), rgba(16, 15, 16, 0.78)),
+        radial-gradient(circle at top right, #ff2d5e 0%, #a01234 56%, #2a0c15 100%);
       color: #fff;
       padding: 4.5rem 0 5rem;
+      border-bottom: 6px solid var(--brand-red);
     }
 
     nav {
@@ -51,36 +53,31 @@ permalink: /
     .logo {
       display: inline-flex;
       align-items: center;
-      gap: 0.65rem;
+      gap: 0.8rem;
       color: #fff;
       text-decoration: none;
     }
 
-    .logo-mark {
-      width: 78px;
-      height: 48px;
-      display: block;
+    .logo-badge {
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 0.5rem;
+      padding: 0.2rem 0.45rem;
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(227, 18, 63, 0.35);
     }
 
-    .logo-wordmark {
-      display: grid;
-      line-height: 0.9;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      font-family: Georgia, "Times New Roman", serif;
-      font-weight: 900;
-      font-size: 1.45rem;
-      color: #181515;
-      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
+    .logo-mark {
+      width: 170px;
+      height: auto;
+      display: block;
     }
 
     .logo-sub {
       font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      font-size: 0.62rem;
-      letter-spacing: 0.08em;
+      font-size: 0.65rem;
+      letter-spacing: 0.1em;
       font-weight: 700;
       opacity: 0.95;
-      margin-top: 0.2rem;
       color: #fff;
       text-transform: uppercase;
     }
@@ -129,7 +126,7 @@ permalink: /
 
     .btn-primary {
       background: #fff;
-      color: var(--brand-red);
+      color: var(--brand-deep-red);
     }
 
     .btn-secondary {
@@ -188,16 +185,11 @@ permalink: /
 
     @media (max-width: 680px) {
       .logo-mark {
-        width: 62px;
-        height: 38px;
-      }
-
-      .logo-wordmark {
-        font-size: 1.15rem;
+        width: 130px;
       }
 
       .logo-sub {
-        font-size: 0.55rem;
+        font-size: 0.54rem;
       }
     }
   </style>
@@ -207,19 +199,10 @@ permalink: /
     <div class="container">
       <nav>
         <a class="logo" href="#" aria-label="Red Wing Shoes Lafayette home">
-          <svg class="logo-mark" viewBox="0 0 220 130" role="img" aria-hidden="true">
-            <title>Wing logo</title>
-            <g fill="#e20e3c">
-              <path d="M11 112c-2-46 40-81 113-99 37-10 79-15 86-13 4 5-19 27-57 34-53 9-97 24-142 78z"/>
-              <path d="M21 111c30-34 67-52 111-62 26-6 57-8 59-4 1 3-9 16-31 24-32 12-85 17-139 42z"/>
-              <path d="M29 107c23-20 62-34 101-43 20-4 37-6 41-3-1 11-30 24-66 28-31 4-53 9-76 18z"/>
-              <path d="M26 119c11-5 29-12 47-15 17-3 31-3 36 0-5 11-21 19-40 21-17 2-31-1-43-6z"/>
-            </g>
-          </svg>
-          <span>
-            <span class="logo-wordmark">Red<br/>Wing</span>
-            <span class="logo-sub">Shoes Lafayette</span>
+          <span class="logo-badge">
+            <img class="logo-mark" src="assets/red-wing-inspired-logo.svg" alt="Red Wing Shoes logo" />
           </span>
+          <span class="logo-sub">Lafayette, Louisiana</span>
         </a>
         <div class="nav-links">
           <a href="#products">Products</a>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ permalink: /
     }
 
     .brand img {
-      width: 185px;
+      width: 220px;
       max-width: 44vw;
       height: auto;
       display: block;

--- a/index.html
+++ b/index.html
@@ -49,9 +49,39 @@ permalink: /
     }
 
     .logo {
-      font-size: 1.2rem;
-      font-weight: 800;
-      letter-spacing: 0.03em;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      color: #fff;
+      text-decoration: none;
+    }
+
+    .logo-mark {
+      width: 78px;
+      height: 48px;
+      display: block;
+    }
+
+    .logo-wordmark {
+      display: grid;
+      line-height: 0.9;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      font-family: Georgia, "Times New Roman", serif;
+      font-weight: 900;
+      font-size: 1.45rem;
+      color: #181515;
+      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
+    }
+
+    .logo-sub {
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      font-size: 0.62rem;
+      letter-spacing: 0.08em;
+      font-weight: 700;
+      opacity: 0.95;
+      margin-top: 0.2rem;
+      color: #fff;
       text-transform: uppercase;
     }
 
@@ -155,13 +185,42 @@ permalink: /
       font-size: 0.92rem;
       color: #666;
     }
+
+    @media (max-width: 680px) {
+      .logo-mark {
+        width: 62px;
+        height: 38px;
+      }
+
+      .logo-wordmark {
+        font-size: 1.15rem;
+      }
+
+      .logo-sub {
+        font-size: 0.55rem;
+      }
+    }
   </style>
 </head>
 <body>
   <header>
     <div class="container">
       <nav>
-        <div class="logo">Red Wing Shoes Lafayette</div>
+        <a class="logo" href="#" aria-label="Red Wing Shoes Lafayette home">
+          <svg class="logo-mark" viewBox="0 0 220 130" role="img" aria-hidden="true">
+            <title>Wing logo</title>
+            <g fill="#e20e3c">
+              <path d="M11 112c-2-46 40-81 113-99 37-10 79-15 86-13 4 5-19 27-57 34-53 9-97 24-142 78z"/>
+              <path d="M21 111c30-34 67-52 111-62 26-6 57-8 59-4 1 3-9 16-31 24-32 12-85 17-139 42z"/>
+              <path d="M29 107c23-20 62-34 101-43 20-4 37-6 41-3-1 11-30 24-66 28-31 4-53 9-76 18z"/>
+              <path d="M26 119c11-5 29-12 47-15 17-3 31-3 36 0-5 11-21 19-40 21-17 2-31-1-43-6z"/>
+            </g>
+          </svg>
+          <span>
+            <span class="logo-wordmark">Red<br/>Wing</span>
+            <span class="logo-sub">Shoes Lafayette</span>
+          </span>
+        </a>
         <div class="nav-links">
           <a href="#products">Products</a>
           <a href="#about">About</a>


### PR DESCRIPTION
### Motivation
- Replace the Jekyll slideshow presentation with a standalone landing page for a local Red Wing Shoes Lafayette storefront.  
- Provide a simple, responsive, branded static page that presents product lines, store details, and calls-to-action for visitors.

### Description
- Updated front-matter to `layout: null` and `permalink: /` and removed the Liquid loop that rendered `site.posts` and slide includes from `index.html`.  
- Replaced the slideshow with a full static HTML document in `index.html` including `<head>`, inline CSS variables and responsive styles, and a semantic page structure (`header`, `main`, `section`, `footer`).  
- Added content sections for `#products`, `#about`, and `#visit`, a hero area with CTAs, and a small inline script `document.getElementById('year').textContent = new Date().getFullYear();` to populate the copyright year.

### Testing
- No automated tests were configured or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fb754e888327a5ddf98a1dd4ccff)